### PR TITLE
fixed ../Casks/ path in app.js and /modules/parse-cask-files.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ var FS              = require('q-io/fs'),
     brewTpl         = require('./templates/brew-template'),
 
     // paths
-    caskPath        = '/usr/local/Library/Taps/phinze-cask/Casks/',
+    caskPath        = '/usr/local/Library/Taps/caskroom/homebrew-cask/Casks/',
 
     // set by args
     overwriteFiles  = getArgv.f ? 'w' : 'wx',

--- a/modules/parse-cask-files.js
+++ b/modules/parse-cask-files.js
@@ -15,7 +15,7 @@ var _               = require('lodash'),
     // paths
     optPath         = '/opt/homebrew-cask/Caskroom/',
     appPath         = '/Applications',
-    caskPath        = '/usr/local/Library/Taps/phinze-cask/Casks/',
+    caskPath        = '/usr/local/Library/Taps/caskroom/homebrew-cask/Casks/',
 
     // instantiate arrays
     optFiles        = [],


### PR DESCRIPTION
Seems that I fixed Issue #5 (at least for myself).
I had to change caskPath from '/usr/local/Library/Taps/phinze-cask/Casks/' to
'/usr/local/Library/Taps/caskroom/homebrew-cask/Casks/'.

This also fixes https://github.com/seethroughtrees/homebrew-dotfile-generator/issues/5

greetings,

Florian
